### PR TITLE
Exception when setting string with capital letters

### DIFF
--- a/lib/key_path/enumerable/extensions.rb
+++ b/lib/key_path/enumerable/extensions.rb
@@ -43,7 +43,11 @@ module Enumerable
     end
 
     # assign it
-    eval "collection#{depth} = #{value}"
+    if value.is_a? String
+      eval "collection#{depth} = '#{value}'"
+    else
+      eval "collection#{depth} = #{value}"
+    end
     
     # merge the new collection into self
     self.deep_merge!(collection)

--- a/spec/enumerable_extensions_spec.rb
+++ b/spec/enumerable_extensions_spec.rb
@@ -61,11 +61,22 @@ describe 'EnumerableExtensions' do
     value = 'value'
 
     source.set_keypath(keypath, value)
-
+    
     source.value_at_keypath(keypath).must_equal(value)
   end
+  
+  
+  it 'can set a string with capital letters' do
+    source = {:item => {:id => {}}}
+    keypath = KeyPath::Path.new('item.id')
+    value = 'VALUE'
 
-
+    source.set_keypath(keypath, value)
+    
+    source.value_at_keypath(keypath).must_equal(value)
+  end
+  
+  
   it 'can set a hash for a path' do
     source = {:item => {:id => {}}}
     keypath = KeyPath::Path.new('item')


### PR DESCRIPTION
I was trying to do the following:

``` ruby
  data.set_keypath(path, 'http://github.com/')
```

And I get the error:
```
./key_path-1.0.0/lib/key_path/enumerable/extensions.rb:46:
in `eval': (eval):1: syntax error, unexpected tLABEL (SyntaxError)
collection[:item][:url] = http://github.com/
                               ^
(eval):1: unknown regexp options - gthb
(eval):1: syntax error, unexpected end-of-input
collection[:item][:url] = http://github.com/
                                            ^
        from ./key_path-1.0.0/lib/key_path/enumerable/extensions.rb:46:in `set_keypath'
```

Also, a similar error for strings with capital letters:

``` ruby
  data.set_keypath(path, 'VALUE')
```
Generates the error:

```
./key_path-1.0.0/lib/key_path/enumerable/extensions.rb:46:
in `eval': uninitialized constant Enumerable::VALUE (NameError)
        from ./key_path-1.0.0/lib/key_path/enumerable/extensions.rb:46:in `eval'
        from ./key_path-1.0.0/lib/key_path/enumerable/extensions.rb:46:in `set_keypath'
```

This is because "eval" tries to evaluate the contents of the string as code. I have added a test case for this with a string with capital letter. Initially it failed. So then I added the fix by adding single quotes to the "value" in the eval string. This makes "eval" evaluate the examples above as strings. Numbers and other objects are left untouched.

Please let me know if I am missing something and I will fix it.